### PR TITLE
Initial checkin of xplat logic for NegotiateStream

### DIFF
--- a/src/Common/src/Interop/Unix/libgssapi/Interop.GssApi.cs
+++ b/src/Common/src/Interop/Unix/libgssapi/Interop.GssApi.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using SafeGssHandle = Interop.libgssapi.SafeGssHandle;
+using SafeGssBufferHandle = Interop.libgssapi.SafeGssBufferHandle;
+using SafeGssNameHandle = Interop.libgssapi.SafeGssNameHandle;
+using SafeGssCredHandle = Interop.libgssapi.SafeGssCredHandle;
+using SafeGssContextHandle = Interop.libgssapi.SafeGssContextHandle;
+using OM_uint32 = System.UInt32;
+
+internal static partial class Interop
+{
+    internal static class GssApi
+    {
+        internal static bool EstablishSecurityContext(
+            ref SafeGssContextHandle context,
+            SafeGssCredHandle credential,
+            SafeGssNameHandle targetName,
+            OM_uint32 inFlags,
+            byte[] inputBuffer,
+            out byte[] outputBuffer,
+            out OM_uint32 outFlags)
+        {
+            outputBuffer = null;
+            outFlags = 0;
+
+            if (context == null)
+            {
+                context = new SafeGssContextHandle();
+            }
+
+            unsafe
+            {
+                fixed (byte* bytePtr = inputBuffer)
+                {
+                    int inputSize = (inputBuffer == null) ? 0 : inputBuffer.Length;
+                    IntPtr inputPtr = (inputSize == 0) ? IntPtr.Zero : new IntPtr(bytePtr);
+
+                    using (SafeGssBufferHandle inputToken = new SafeGssBufferHandle(inputSize, inputPtr))
+                    using (SafeGssBufferHandle outputToken = new SafeGssBufferHandle())
+                    {
+                        OM_uint32 status, minorStatus, outTime;
+
+                        if (targetName == null)
+                        {
+                            status = libgssapi.gss_accept_sec_context(
+                                         out minorStatus,
+                                         ref context,
+                                         credential,
+                                         inputToken,
+                                         SafeGssHandle.Instance,
+                                         SafeGssHandle.Instance,
+                                         SafeGssHandle.Instance,
+                                         outputToken,
+                                         out outFlags,
+                                         out outTime,
+                                         SafeGssHandle.Instance);
+                        }
+                        else
+                        {
+                            status = libgssapi.gss_init_sec_context(
+                                         out minorStatus,
+                                         credential,
+                                         ref context,
+                                         targetName,
+                                         ref libgssapi.GSS_SPNEGO_MECHANISM,
+                                         inFlags,
+                                         0,
+                                         SafeGssHandle.Instance,
+                                         inputToken,
+                                         SafeGssHandle.Instance,
+                                         outputToken,
+                                         out outFlags,
+                                         out outTime);
+                        }
+
+                        if ((status != libgssapi.Status.GSS_S_COMPLETE) && (status != libgssapi.Status.GSS_S_CONTINUE_NEEDED))
+                        {
+                            throw libgssapi.GssApiException.Create(SR.net_context_establishment_failed, status, minorStatus);
+                        }
+
+                        outputBuffer = new byte[outputToken.Length]; // Always return non-null
+                        if (outputToken.Length > 0)
+                        {
+                            Marshal.Copy(outputToken.Value, outputBuffer, 0, outputToken.Length);
+                        }
+
+                        return (status == libgssapi.Status.GSS_S_COMPLETE) ? true : false;
+                    }
+                }
+            }
+        }
+
+        internal static int Encrypt(
+            SafeGssContextHandle context,
+            bool encrypt,
+            byte[] inputBuffer,
+            int offset,
+            int count,
+            out byte[] outputBuffer)
+        {
+            outputBuffer = null;
+            Debug.Assert((inputBuffer != null) && (inputBuffer.Length > 0), "Invalid input buffer passed to Encrypt");
+            Debug.Assert((offset >= 0) && (offset < inputBuffer.Length), "Invalid input offset passed to Encrypt");
+            Debug.Assert((count > 0) && (count <= (inputBuffer.Length - offset)), "Invalid input count passed to Encrypt");
+
+            unsafe
+            {
+                fixed (byte* bytePtr = inputBuffer)
+                {
+                    using (SafeGssBufferHandle inputToken = new SafeGssBufferHandle(count, new IntPtr(bytePtr + offset)))
+                    using (SafeGssBufferHandle outputToken = new SafeGssBufferHandle())
+                    {
+                        OM_uint32 status, minorStatus;
+                        int outConf;
+                        int inConf = encrypt ? 1 : 0;
+
+                        status = libgssapi.gss_wrap(out minorStatus, context, inConf, libgssapi.GSS_C_QOP_DEFAULT, inputToken, out outConf, outputToken);
+                        if (status != libgssapi.Status.GSS_S_COMPLETE)
+                        {
+                            throw libgssapi.GssApiException.Create(SR.net_context_wrap_failed, status, minorStatus);
+                        }
+                        Debug.Assert((outConf == 0) == (inConf == 0), "Encryption/signing failed. Expected: " + inConf + " Actual: " + outConf);
+
+                        outputBuffer = new byte[outputToken.Length]; // Always return non-null
+                        if (outputToken.Length > 0)
+                        {
+                            Marshal.Copy(outputToken.Value, outputBuffer, 0, outputToken.Length);
+                        }
+                        return outputBuffer.Length;
+                    }
+                }
+            }
+        }
+
+        internal static int Decrypt(
+            SafeGssContextHandle context,
+            byte[] inputBuffer,
+            int offset,
+            int count)
+        {
+            Debug.Assert((inputBuffer != null) && (inputBuffer.Length > 0), "Invalid input buffer passed to Decrypt");
+            Debug.Assert((offset >= 0) && (offset < inputBuffer.Length), "Invalid input offset passed to Decrypt");
+            Debug.Assert((count > 0) && (count <= (inputBuffer.Length - offset)), "Invalid input count passed to Decrypt");
+
+            unsafe
+            {
+                fixed (byte* bytePtr = inputBuffer)
+                {
+                    using (SafeGssBufferHandle inputToken = new SafeGssBufferHandle(count, new IntPtr(bytePtr + offset)))
+                    using (SafeGssBufferHandle outputToken = new SafeGssBufferHandle())
+                    {
+                        OM_uint32 status, minorStatus, outQOP;
+                        int outConf;
+
+                        status = libgssapi.gss_unwrap(out minorStatus, context, inputToken, outputToken, out outConf, out outQOP);
+                        if (status != libgssapi.Status.GSS_S_COMPLETE)
+                        {
+                            throw libgssapi.GssApiException.Create(SR.net_context_unwrap_failed, status, minorStatus);
+                        }
+
+                        if (outputToken.Length > inputBuffer.Length)
+                        {
+                            throw libgssapi.GssApiException.Create(SR.Format(SR.net_context_buffer_too_small, outputToken.Length, inputBuffer.Length));
+                        }
+
+                        if (outputToken.Length > 0)
+                        {
+                            Marshal.Copy(outputToken.Value, inputBuffer, 0, outputToken.Length);
+                        }
+                        return outputToken.Length;
+                    }
+                }
+            }
+        }
+
+        internal static string GetSourceName(SafeGssContextHandle context)
+        {
+            OM_uint32 status, minorStatus, lifetime, contextFlags;
+            int localContext, openContext;
+            SafeGssNameHandle sourceName;
+
+            status = libgssapi.gss_inquire_context(
+                         out minorStatus,
+                         context,
+                         out sourceName,
+                         SafeGssHandle.Instance,
+                         out lifetime,
+                         SafeGssHandle.Instance,
+                         out contextFlags,
+                         out localContext,
+                         out openContext);
+            if (status != libgssapi.Status.GSS_S_COMPLETE)
+            {
+                throw libgssapi.GssApiException.Create(status, minorStatus);
+            }
+
+            try
+            {
+                using (SafeGssBufferHandle outputBuffer = new SafeGssBufferHandle())
+                {
+                    status = libgssapi.gss_display_name(out minorStatus, sourceName, outputBuffer, SafeGssHandle.Instance);
+                    if (status != libgssapi.Status.GSS_S_COMPLETE)
+                    {
+                        throw libgssapi.GssApiException.Create(status, minorStatus);
+                    }
+
+                    // String may not be NULL terminated so PtrToStringAnsi cannot be used
+                    unsafe
+                    {
+                        return Encoding.UTF8.GetString((byte*)outputBuffer.Value.ToPointer(), outputBuffer.Length);
+                    }
+                }
+            }
+            finally
+            {
+                sourceName.Dispose();
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libgssapi/Interop.GssApiException.cs
+++ b/src/Common/src/Interop/Unix/libgssapi/Interop.GssApiException.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using OM_uint32 = System.UInt32;
+
+internal static partial class Interop
+{
+    internal static partial class libgssapi
+    {
+        internal sealed class GssApiException : Exception
+        {
+            private OM_uint32 _minorStatus;
+
+            public OM_uint32 MinorStatus
+            {
+                get { return _minorStatus;  }
+            }
+
+            public GssApiException(string message) : base(message)
+            {
+            }
+
+            public GssApiException(OM_uint32 majorStatus, OM_uint32 minorStatus)
+                : base(SR.Format(SR.net_generic_operation_failed, majorStatus, minorStatus))
+            {
+                HResult = (int)majorStatus;
+                _minorStatus = minorStatus;
+            }
+
+            public GssApiException(string message, OM_uint32 majorStatus, OM_uint32 minorStatus)
+                : base(message)
+            {
+                HResult = (int)majorStatus;
+                _minorStatus = minorStatus;
+            }
+
+
+            public static GssApiException Create(string message)
+            {
+                return new GssApiException(message);
+            }
+
+            public static GssApiException Create(OM_uint32 majorStatus, OM_uint32 minorStatus)
+            {
+                return new GssApiException(majorStatus, minorStatus);
+            }
+
+            public static GssApiException Create(string message, OM_uint32 majorStatus, OM_uint32 minorStatus)
+            {
+                return new GssApiException(SR.Format(message, majorStatus, minorStatus), majorStatus, minorStatus);
+            }
+
+            public static void AssertOrThrowIfError(string message, OM_uint32 majorStatus, OM_uint32 minorStatus)
+            {
+                if (majorStatus != Status.GSS_S_COMPLETE)
+                {
+                    var ex = Create(majorStatus, minorStatus);
+                    Debug.Fail(message + ": " + ex);
+                    throw ex;
+                }
+            }
+
+#if DEBUG
+            public override string ToString()
+            {
+                return Message + "\n GSSAPI status: " + GetGssApiDisplayStatus((OM_uint32)HResult, _minorStatus);
+            }
+
+            private static string GetGssApiDisplayStatus(OM_uint32 majorStatus, OM_uint32 minorStatus)
+            {
+                OM_uint32[] statusArr = new OM_uint32[] { majorStatus, minorStatus };
+                int[] msgTypes = new int[] { StatusType.GSS_C_GSS_CODE, StatusType.GSS_C_MECH_CODE };
+                string[] msgStrings = new string[2];
+
+                for (int i = 0; i < msgTypes.Length; i++)
+                {
+                    using (SafeGssBufferHandle msgBuffer = new SafeGssBufferHandle())
+                    {
+                        OM_uint32 minStat, msgCtx = 0;
+                        if (Status.GSS_S_COMPLETE != gss_display_status(out minStat, statusArr[i], msgTypes[i], SafeGssHandle.Instance, ref msgCtx, msgBuffer))
+                        {
+                            continue;
+                        }
+                        msgStrings[i] = Marshal.PtrToStringAnsi(msgBuffer.Value);
+                    }
+                }
+                return msgStrings[0] + " (" + msgStrings[1] + ") + Status: " + majorStatus.ToString("x8") + " (" + minorStatus.ToString("x8") + ")";
+            }
+        }
+    }
+#endif
+}

--- a/src/Common/src/Interop/Unix/libgssapi/Interop.SafeGssHandle.cs
+++ b/src/Common/src/Interop/Unix/libgssapi/Interop.SafeGssHandle.cs
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+using OM_uint32 = System.UInt32;
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class libgssapi
+    {
+        /// <summary>
+        /// Wrapper around a gss_buffer_desc*
+        /// </summary>
+        internal sealed class SafeGssBufferHandle : SafeHandle
+        {
+            private int _length;
+            private IntPtr _value;
+
+            // Return the buffer size
+            public int Length
+            {
+                get
+                {
+                    if (IsInvalid)
+                    {
+                        return 0;
+                    }
+                    _length = Marshal.ReadInt32(handle);
+                    return _length;
+                }
+            }
+
+            // Return a pointer to where data resides
+            public IntPtr Value
+            {
+                get
+                {
+                    if (IsInvalid)
+                    {
+                        return IntPtr.Zero;
+                    }
+                    _value = Marshal.ReadIntPtr(handle, (int)Marshal.OffsetOf<gss_buffer_desc>("value"));
+                    return _value;
+                }
+            }
+
+            public SafeGssBufferHandle() : this(0, IntPtr.Zero)
+            {
+            }
+
+            public SafeGssBufferHandle(int length, IntPtr value) : base(IntPtr.Zero, length==0)
+            {
+                _length = length;
+                _value = value;
+                gss_buffer_desc buffer = new gss_buffer_desc
+                    {
+                        length = (size_t)_length,
+                        value = _value,
+                    };
+                handle = Marshal.AllocHGlobal(Marshal.SizeOf<gss_buffer_desc>());
+                Marshal.StructureToPtr(buffer, handle, false);
+            }
+
+            public override bool IsInvalid
+            {
+                get { return handle == IntPtr.Zero; }
+            }
+
+            // Note that _value should never be freed directly. For input
+            // buffer, it is owned by the caller and for output buffer,
+            // it is owned by libgssapi
+            protected override bool ReleaseHandle()
+            {
+                if (_value == IntPtr.Zero)
+                {
+                    _value = Marshal.ReadIntPtr(handle, (int)Marshal.OffsetOf<gss_buffer_desc>("value"));
+                }
+                if (_value != IntPtr.Zero)
+                {
+                    OM_uint32 status, minorStatus;
+                    status = gss_release_buffer(out minorStatus, handle);
+                    GssApiException.AssertOrThrowIfError("gss_release_buffer failed", status, minorStatus);
+                }
+                Marshal.FreeHGlobal(handle);
+                SetHandle(IntPtr.Zero);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Wrapper around a gss_name_t_desc*
+        /// </summary>
+        internal sealed class SafeGssNameHandle : SafeHandle
+        {
+            public SafeGssNameHandle(string name, gss_OID_desc type) : base(IntPtr.Zero, true)
+            {
+                Debug.Assert(!String.IsNullOrEmpty(name), "Invalid name passed to SafeGssNameHandle");
+                IntPtr namePtr = Marshal.StringToHGlobalAnsi(name);
+                try
+                {
+                    using (SafeGssBufferHandle buffer = new SafeGssBufferHandle(name.Length, namePtr))
+                    {
+                        OM_uint32 status, minorStatus;
+                        status = gss_import_name(out minorStatus, buffer, ref type, ref handle);
+                        GssApiException.AssertOrThrowIfError("gss_import_name failed", status, minorStatus);
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(namePtr);
+                }
+            }
+
+            public override bool IsInvalid
+            {
+                get { return handle == IntPtr.Zero; }
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                OM_uint32 status, minorStatus;
+                status = gss_release_name(out minorStatus, ref handle);
+                GssApiException.AssertOrThrowIfError("gss_release_name failed", status, minorStatus);
+                return true;
+            }
+
+            private SafeGssNameHandle() : base (IntPtr.Zero, true)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Wrapper around a gss_cred_id_t_desc_struct*
+        /// </summary>
+        internal class SafeGssCredHandle : SafeHandle
+        {
+            private static gss_OID_set_desc s_spnegoSet = new gss_OID_set_desc
+                {
+                    count = (size_t)1,
+                    elements = GCHandle.Alloc(GSS_SPNEGO_MECHANISM, GCHandleType.Pinned).AddrOfPinnedObject(),
+                };
+
+            public SafeGssCredHandle(string username, string password, string domain) : base(IntPtr.Zero, true)
+            {
+                // Empty username is OK if Kerberos ticket was already obtained
+                if (!String.IsNullOrEmpty(username))
+                {
+                    using (SafeGssNameHandle userHandle = new SafeGssNameHandle(username, GSS_C_NT_USER_NAME))
+                    {
+                        OM_uint32 status, minorStatus, outTime;
+                        if (String.IsNullOrEmpty(password))
+                        {
+                            status = gss_acquire_cred(out minorStatus, userHandle, 0, ref s_spnegoSet,
+                                    gss_cred_usage_t.GSS_C_INITIATE, ref handle, SafeGssHandle.Instance, out outTime);
+                            GssApiException.AssertOrThrowIfError("gss_acquire_cred failed", status, minorStatus);
+                        }
+                        else
+                        {
+                            IntPtr passwordPtr = Marshal.StringToHGlobalAnsi(password);
+                            try
+                            {
+                                using (SafeGssBufferHandle buffer = new SafeGssBufferHandle(password.Length, passwordPtr))
+                                {
+                                    status = gss_acquire_cred_with_password(out minorStatus, userHandle, buffer, 0, ref s_spnegoSet,
+                                            gss_cred_usage_t.GSS_C_INITIATE, ref handle, SafeGssHandle.Instance, out outTime);
+                                    GssApiException.AssertOrThrowIfError("gss_acquire_cred_with_password failed", status, minorStatus);
+                                }
+                            }
+                            finally
+                            {
+                                Marshal.FreeHGlobal(passwordPtr);
+                            }
+                        }
+                    }
+                }
+            }
+
+            public override bool IsInvalid
+            {
+                get { return handle == IntPtr.Zero; }
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                OM_uint32 status, minorStatus;
+                status = gss_release_cred(out minorStatus, ref handle);
+                GssApiException.AssertOrThrowIfError("gss_release_cred failed", status, minorStatus);
+                return true;
+            }
+        }
+
+        internal sealed class SafeGssContextHandle : SafeHandle
+        {
+            public SafeGssContextHandle() : base(IntPtr.Zero, true)
+            {
+            }
+
+            public override bool IsInvalid
+            {
+                get { return handle == IntPtr.Zero; }
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                OM_uint32 status, minorStatus;
+                status = gss_delete_sec_context(out minorStatus, ref handle, new SafeGssBufferHandle());
+                GssApiException.AssertOrThrowIfError("gss_delete_sec_context failed", status, minorStatus);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Generic handle to wrap an IntPtr.Zero in p/invokes
+        /// Use SafeGssHandle.Instance for all p/invoke parameters
+        /// expecting a SafeGssHandle
+        /// </summary>
+        internal class SafeGssHandle : SafeHandle
+        {
+            internal static readonly SafeGssHandle Instance = new SafeGssHandle();
+
+            private SafeGssHandle() : base (IntPtr.Zero, false)
+            {
+            }
+
+            public override bool IsInvalid
+            {
+                get { return true; }
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                Debug.Fail("Unexpected release of SafeGssHandle");
+                return false;
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libgssapi/Interop.libgssapi.cs
+++ b/src/Common/src/Interop/Unix/libgssapi/Interop.libgssapi.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using OM_uint32 = System.UInt32;
+
+internal static partial class Interop
+{
+    internal static partial class Libraries
+    {
+        // TODO (Issue #3715): Figure out the correct library on OSX
+        internal const string LibGssApi = "libgssapi_krb5.so.2";
+    }
+
+    internal static partial class libgssapi
+    {
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_release_buffer(
+            out OM_uint32 minor_status,
+            IntPtr buffer);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_display_status(
+            out OM_uint32 minor_status,
+            OM_uint32 status_value,
+            int status_type,
+            SafeGssHandle mech_type,
+            ref OM_uint32 message_context,
+            SafeGssBufferHandle status_string);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_import_name(
+            out OM_uint32 minor_status,
+            SafeGssBufferHandle input_name_buffer,
+            ref gss_OID_desc input_name_type,
+            ref IntPtr output_name);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_release_name(
+            out OM_uint32 minor_status,
+            ref IntPtr input_name);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_acquire_cred(
+            out OM_uint32 minor_status,
+            SafeGssNameHandle desired_name,
+            OM_uint32 time_req,
+            ref gss_OID_set_desc desired_mechs,
+            int cred_usage,
+            ref IntPtr output_cred_handle,
+            SafeGssHandle actual_mechs,
+            out OM_uint32 time_rec);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_acquire_cred_with_password(
+            out OM_uint32 minor_status,
+            SafeGssNameHandle desired_name,
+            SafeGssBufferHandle password,
+            OM_uint32 time_req,
+            ref gss_OID_set_desc desired_mechs,
+            int cred_usage,
+            ref IntPtr output_cred_handle,
+            SafeGssHandle actual_mechs,
+            out OM_uint32 time_rec);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_release_cred(
+            out OM_uint32 minor_status,
+            ref IntPtr cred_handle);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_init_sec_context(
+            out OM_uint32 minor_status,
+            SafeGssCredHandle initiator_cred_handle,
+            ref SafeGssContextHandle context_handle,
+            SafeGssNameHandle target_name,
+            ref gss_OID_desc mech_type,
+            OM_uint32 req_flags,
+            OM_uint32 time_req,
+            SafeGssHandle input_chain_bindings,
+            SafeGssBufferHandle input_token,
+            SafeGssHandle actual_mech_type,
+            SafeGssBufferHandle output_token,
+            out OM_uint32 ret_flags,
+            out OM_uint32 time_rec);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_accept_sec_context(
+            out OM_uint32 minor_status,
+            ref SafeGssContextHandle context_handle,
+            SafeGssCredHandle initiator_cred_handle,
+            SafeGssBufferHandle input_token,
+            SafeGssHandle input_chan_bindings,
+            SafeGssHandle src_name,
+            SafeGssHandle mech_type,
+            SafeGssBufferHandle output_token,
+            out OM_uint32 ret_flags,
+            out OM_uint32 time_rec,
+            SafeGssHandle delegated_cred_handle);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_delete_sec_context(
+            out OM_uint32 minor_status,
+            ref IntPtr context_handle,
+            SafeGssBufferHandle buffer);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_wrap(
+            out OM_uint32 minor_status,
+            SafeGssContextHandle context_handle,
+            int conf_req_flag,
+            OM_uint32 qop_req,
+            SafeGssBufferHandle input_message_buffer,
+            out int conf_state,
+            SafeGssBufferHandle output_message_buffer);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_unwrap(
+            out OM_uint32 minor_status,
+            SafeGssContextHandle context_handle,
+            SafeGssBufferHandle input_message_buffer,
+            SafeGssBufferHandle output_message_buffer,
+            out int conf_state,
+            out OM_uint32 qop_state);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_inquire_context(
+            out OM_uint32 minor_status,
+            SafeGssContextHandle context_handle,
+            out SafeGssNameHandle src_name,
+            SafeGssHandle targ_name,
+            out OM_uint32 lifetime_rec,
+            SafeGssHandle mech_type,
+            out OM_uint32 ctx_flags,
+            out int locally_initiated,
+            out int open_context);
+
+        [DllImport(Interop.Libraries.LibGssApi)]
+        internal static extern OM_uint32 gss_display_name(
+            out OM_uint32 minor_status,
+            SafeGssNameHandle input_name,
+            SafeGssBufferHandle output_name_buffer,
+            SafeGssHandle output_name_type);
+    }
+}

--- a/src/Common/src/Interop/Unix/libgssapi/Interop.libgssapi_types.cs
+++ b/src/Common/src/Interop/Unix/libgssapi/Interop.libgssapi_types.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using OM_uint32 = System.UInt32;
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class libgssapi
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct gss_buffer_desc
+        {
+            internal size_t length;
+            internal IntPtr value;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct gss_OID_desc
+        {
+            internal OM_uint32 length;
+            internal uint padding;
+            internal IntPtr elements;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct gss_OID_set_desc
+        {
+            internal size_t count;
+            internal IntPtr elements;
+        }
+
+        internal partial class Status
+        {
+            internal const OM_uint32 GSS_S_COMPLETE = 0;
+            internal const OM_uint32 GSS_S_CONTINUE_NEEDED = 1;
+        }
+
+        internal partial class StatusType
+        {
+            internal const int GSS_C_GSS_CODE = 1;
+            internal const int GSS_C_MECH_CODE = 2;
+        }
+
+        [FlagsAttribute]
+        internal enum ContextFlags : uint
+        {
+            GSS_C_DELEG_FLAG = 1,
+            GSS_C_MUTUAL_FLAG = 2,
+            GSS_C_REPLAY_FLAG = 4,
+            GSS_C_SEQUENCE_FLAG = 8,
+            GSS_C_CONF_FLAG = 16,
+            GSS_C_INTEG_FLAG = 32,
+            GSS_C_ANON_FLAG = 64,
+            GSS_C_PROT_READY_FLAG = 128,
+            GSS_C_TRANS_FLAG = 256,
+            GSS_C_DCE_STYLE = 4096,
+            GSS_C_IDENTIFY_FLAG = 8192,
+            GSS_C_EXTENDED_ERROR_FLAG = 16384,
+            GSS_C_DELEG_POLICY_FLAG = 32768
+        }
+
+        internal static partial class gss_cred_usage_t
+        {
+            internal const int GSS_C_INITIATE = 1;
+        }
+
+        internal const OM_uint32 GSS_C_QOP_DEFAULT = 0;
+
+        internal static gss_OID_desc GSS_C_NT_USER_NAME = new gss_OID_desc
+            {
+                length = 10,
+                padding = 0,
+                elements = GCHandle.Alloc(new byte[] {0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x01, 0x01}, GCHandleType.Pinned).AddrOfPinnedObject(),
+            };
+
+        internal static gss_OID_desc GSS_KRB5_NT_PRINCIPAL_NAME = new gss_OID_desc
+            {
+                length = 10,
+                padding = 0,
+                elements = GCHandle.Alloc(new byte[] {0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02, 0x01}, GCHandleType.Pinned).AddrOfPinnedObject(),
+            };
+
+        internal static gss_OID_desc GSS_SPNEGO_MECHANISM = new gss_OID_desc
+            {
+                length = 6,
+                padding = 0,
+                elements = GCHandle.Alloc(new byte[] {0x2b, 0x06, 0x01, 0x05, 0x05, 0x02}, GCHandleType.Pinned).AddrOfPinnedObject(),
+            };
+    }
+}

--- a/src/Common/src/Interop/Unix/libgssapi/MockNego.csproj
+++ b/src/Common/src/Interop/Unix/libgssapi/MockNego.csproj
@@ -1,0 +1,97 @@
+﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>MockNego</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Exe</OutputType>
+    <ProjectGuid>{89F37791-6254-4D60-AB96-ACD3CCA0E771}</ProjectGuid>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);FEATURE_CORECLR;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
+
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">  
+    <Compile Include="Program.cs"/>
+    <Compile Include="MockNegotiateStream.cs"/>
+    <Compile Include="MockUtils.cs"/>
+    <Compile Include="Interop.libgssapi.cs"/>
+    <Compile Include="Interop.libgssapi_types.cs"/>
+    <Compile Include="Interop.GssApi.cs"/>
+    <Compile Include="Interop.GssApiException.cs"/>
+    <Compile Include="Interop.SafeGssHandle.cs"/>
+    <Compile Include="..\libheimntlm\Interop.Crypto.cs"/>
+    <Compile Include="..\libheimntlm\Interop.libheimntlm.cs"/>
+    <Compile Include="..\libheimntlm\Interop.libheimntlm_types.cs"/>
+    <Compile Include="..\libheimntlm\Interop.HeimdalNtlm.cs"/>
+    <Compile Include="..\libheimntlm\Interop.HeimdalNtlmException.cs"/>
+    <Compile Include="..\libheimntlm\Interop.SafeNtlmHandle.cs"/>
+    <Compile Include="..\..\..\..\..\System.Net.Security\src\System\Net\_SecurityBuffer.cs" />
+    <Compile Include="..\..\..\..\..\System.Net.Security\src\System\Net\_SecurityBufferType.cs" />
+    <Compile Include="..\..\..\..\..\System.Net.Security\src\System\Net\NegotiateStreamPal.Unix.cs" />
+    <Compile Include="..\..\..\..\..\System.Net.Security\src\System\Net\SecurityStatus.cs" />
+    <Compile Include="..\..\..\..\..\System.Net.Security\src\System\Net\Unix\SecuritySafeHandles.cs" />
+    <!--Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafePkcs7Handle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafePkcs7Handle.Unix.cs</Link>
+    </Compile-->
+
+    <!-- Logging -->
+    <Compile Include="$(CommonPath)\System\Net\Shims\TraceSource.cs">
+      <Link>Common\System\Net\Shims\TraceSource.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\Logging.cs">
+      <Link>Common\System\Net\Logging\Logging.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\GlobalLog.cs">
+      <Link>Common\System\Net\Logging\GlobalLog.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\EventSourceLogging.cs">
+      <Link>Common\System\Net\Logging\EventSourceLogging.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
+      <Link>Common\System\Net\InternalException.cs</Link>
+    </Compile>
+
+    <!-- Debug only --> 
+    <Compile Include="$(CommonPath)\System\Net\DebugSafeHandle.cs">
+      <Link>Common\System\Net\DebugSafeHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs">
+      <Link>Common\System\Net\DebugCriticalHandleMinusOneIsInvalid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs">
+      <Link>Common\System\Net\DebugCriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
+    </Compile>
+
+    <!-- Common -->
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\CriticalHandleMinusOneIsInvalid.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\CriticalHandleMinusOneIsInvalid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\CriticalHandleZeroOrMinusOneIsInvalid.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\CriticalHandleZeroOrMinusOneIsInvalid.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\NotImplemented.cs" >
+      <Link>Common\System\NotImplemented.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs</Link>
+    </Compile>
+
+   
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />  
+</Project>

--- a/src/Common/src/Interop/Unix/libgssapi/MockNegotiateStream.cs
+++ b/src/Common/src/Interop/Unix/libgssapi/MockNegotiateStream.cs
@@ -1,0 +1,281 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+
+namespace System.Net
+{
+    internal class NegotiationInfoClass
+    {
+        internal const string NTLM = "NTLM";
+        internal const string Kerberos = "Kerberos";
+        internal const string Negotiate = "Negotiate";
+        internal string AuthenticationPackage;
+        internal NegotiationInfoClass(SafeHandle safeHandle, int negotiationState)
+        {
+        }
+    }
+}
+
+namespace System.Net.Security
+{
+    public enum EncryptionPolicy
+    {
+        // Prohibit null ciphers (current system defaults)
+        RequireEncryption = 0,
+
+        // Add null ciphers to current system defaults
+        AllowNoEncryption,
+
+        // Request null ciphers only
+        NoEncryption
+    }
+}
+
+namespace MockNegotiateStream
+{
+    using MockUtils;
+    using System.Net.Security;
+
+    using OM_uint32 = System.UInt32;
+    using ContextFlags = Interop.libgssapi.ContextFlags;
+    using NtlmFlags = Interop.libheimntlm.NtlmFlags;
+
+    internal class MockCredential
+    {
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string Domain { get; set; }
+    }
+
+    internal enum MockProtection
+    {
+        None,
+        Sign,
+        EncryptAndSign
+    }
+
+    internal enum MockImpersonation
+    {
+        Anonymous,
+        Delegation,
+        Identification,
+        Impersonation,
+        None
+    }
+
+    internal class MockGenericIdentity
+    {
+        private readonly string _name;
+        public string Name { get { return _name;  } }
+        public string AuthenticationType { get { return string.Empty; } }
+        public bool IsAuthenticated { get { return true; } }
+
+        internal MockGenericIdentity(string name)
+        {
+            _name = name;
+        }
+    }
+
+    internal class MockNegotiateStream
+    {
+        // Does framing per MS-NNS protocol
+        private readonly MockFramer _framer;
+
+        private readonly Stream _stream;
+        private SafeHandle _context;
+        private bool _isSecure;
+        private MockGenericIdentity _identity;
+        private bool _isEncrypted;
+
+        internal MockGenericIdentity RemoteIdentity
+        {
+            get
+            {
+                if (_identity == null)
+                {
+                    SecurityStatus errorCode;
+                    var name = (string) NegotiateStreamPal.QueryContextAttributes((SafeDeleteGssContext)_context, 0x01, out errorCode);
+                    _identity = new MockGenericIdentity(name);
+                }
+                return _identity;
+            }
+        }
+
+        internal MockNegotiateStream(Stream innerStream)
+        {
+            _stream = innerStream;
+            _framer = new MockFramer(_stream);
+        }
+
+        internal void AuthenticateAsClient(MockCredential cred, object channelBinding, string target, MockProtection protection=MockProtection.EncryptAndSign, MockImpersonation impersonation=MockImpersonation.Identification)
+        {
+            _isSecure = (protection != MockProtection.None);
+            _isEncrypted = (protection == MockProtection.EncryptAndSign);
+            SafeHandle inCred;
+            var isNtlm = string.IsNullOrEmpty(target) || (protection == MockProtection.None);
+            var package = isNtlm ? "NTLM" : "Negotiate";
+            NegotiateStreamPal.AcquireCredentialsHandle(package, false, cred.UserName, cred.Password, cred.Domain, out inCred);
+            //NegotiateStreamPal.AcquireDefaultCredential(string.Empty, false, out inCred);
+            byte[] inBuf = null;
+            while(true)
+            {
+                SecurityBuffer[] inputBuffers = new SecurityBuffer[] {new SecurityBuffer(inBuf, SecurityBufferType.Token)};
+                SecurityBuffer outputBuffer = new SecurityBuffer(0, SecurityBufferType.Token);
+                uint outFlags=0;
+                var inFlags = isNtlm ? GetNtlmFlags(false, protection, impersonation) : GetFlags(false, protection, impersonation);
+                var done = NegotiateStreamPal.InitializeSecurityContext(inCred, ref _context, target, inFlags, 0, inputBuffers, outputBuffer, ref outFlags);
+                MockLogging.PrintInfo(null, "____________ DONE: " + done);
+                // TODO: Figure out correct framing logic
+                if (!isNtlm && done==SecurityStatus.OK) break;
+                _framer.WriteMessage(outputBuffer.token);
+                inBuf = _framer.ReadMessage();
+                if ((null == inBuf) || (inBuf.Length == 0)) break;
+            }
+            _identity = new MockGenericIdentity(target);
+        }
+
+        internal void AuthenticateAsServer(MockCredential cred, object extendedProtectionPolicy=null, MockProtection protection=MockProtection.EncryptAndSign, MockImpersonation impersonation=MockImpersonation.Identification)
+        {
+            _isSecure = (protection != MockProtection.None);
+            _isEncrypted = (protection == MockProtection.EncryptAndSign);
+            SafeHandle inCred;
+            NegotiateStreamPal.AcquireCredentialsHandle(string.Empty, true, string.Empty, string.Empty, string.Empty, out inCred);
+            byte[] inBuf = null;
+            while(true)
+            {
+                inBuf = _framer.ReadMessage();
+                SecurityBuffer inputBuffer = new SecurityBuffer(inBuf, SecurityBufferType.Token);
+                SecurityBuffer outputBuffer = new SecurityBuffer(0, SecurityBufferType.Token);
+                uint outFlags=0;
+                var inFlags = GetFlags(false, protection, impersonation);
+                var done = NegotiateStreamPal.AcceptSecurityContext(inCred, ref _context, inputBuffer, inFlags, 0, outputBuffer, ref outFlags);
+                MockLogging.PrintInfo(null, "____________ DONE: " + done);
+                _framer.WriteMessage(outputBuffer.token);
+                if (done==SecurityStatus.OK) break;
+            }
+        }
+
+        internal int Read(byte[] buffer, int offset, int count)
+        {
+            if (!_isSecure) return _framer.ReadData(buffer, offset, count);
+            var internalBuffer = new byte[count];
+            count = _framer.ReadData(internalBuffer, 0, count);
+            int newOffset;
+            if (_isEncrypted) count = NegotiateStreamPal.Decrypt(_context, internalBuffer, 0, count, out newOffset, 0);
+            else count = NegotiateStreamPal.VerifySignature(_context, internalBuffer, 0, count, out newOffset, 0);
+            Array.Copy(internalBuffer, newOffset, buffer, offset, count);
+            return count;
+        }
+
+        internal void Write(byte[] buffer, int offset, int count)
+        {
+            if (!_isSecure)
+            {
+                _framer.WriteData(buffer, offset, count);
+                return; 
+            }
+            byte[] outBuf = null;
+            if (_isEncrypted) count = NegotiateStreamPal.Encrypt(_context, buffer, offset, count, ref outBuf, 0);
+            else count = NegotiateStreamPal.MakeSignature(_context, buffer, offset, count, ref outBuf, 0);
+            _framer.WriteData(outBuf, 0, count);
+        }
+
+#region private
+        private OM_uint32 GetFlags(bool isServer, MockProtection protection, MockImpersonation impersonation)
+        {
+            ContextFlags inFlags=0;
+            if (protection == MockProtection.EncryptAndSign) inFlags = ContextFlags.GSS_C_CONF_FLAG;
+            else if (protection == MockProtection.Sign) inFlags = ContextFlags.GSS_C_REPLAY_FLAG | ContextFlags.GSS_C_SEQUENCE_FLAG;
+            if (!isServer)
+            {
+                if (protection != MockProtection.None) inFlags |= ContextFlags.GSS_C_MUTUAL_FLAG;
+                if (impersonation == MockImpersonation.Identification) inFlags |= ContextFlags.GSS_C_IDENTIFY_FLAG;
+            }
+            return (OM_uint32)inFlags;
+        }
+
+        private uint GetNtlmFlags(bool isServer, MockProtection protection, MockImpersonation impersonation)
+        {
+            uint inFlags = NtlmFlags.NTLMSSP_NEGOTIATE_UNICODE | NtlmFlags.NTLMSSP_REQUEST_TARGET;
+            if (protection != MockProtection.None) inFlags |= NtlmFlags.NTLMSSP_NEGOTIATE_SIGN | NtlmFlags.NTLMSSP_NEGOTIATE_ALWAYS_SIGN | NtlmFlags.NTLMSSP_NEGOTIATE_NTLM | NtlmFlags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY | NtlmFlags.NTLMSSP_NEGOTIATE_128 | NtlmFlags.NTLMSSP_NEGOTIATE_KEY_EXCH;
+            if (protection == MockProtection.EncryptAndSign) inFlags |= NtlmFlags.NTLMSSP_NEGOTIATE_SEAL;
+            return inFlags;
+        }
+
+        private class MockFramer
+        {
+            private readonly Stream _stream;
+            internal byte MessageId = 22; // handshake-in-progress
+            internal MockFramer(Stream innerStream)
+            {
+                _stream = innerStream;
+            }
+            internal void WriteMessage(byte[] message)
+            {
+                // Do MS-NNS framing
+                var header = new byte[5];
+                header[0] = MessageId;
+                header[1] = (byte) 1; // major version
+                header[2] = (byte) 0; // minor version
+                header[3] = (byte) ((message.Length >> 8) & 0xff);
+                header[4] = (byte) (message.Length & 0xff);
+                _stream.Write(header, 0, header.Length);
+                
+                if (message.Length > 0)
+                {
+                    _stream.Write(message, 0, message.Length);
+                }
+            }
+            internal byte[] ReadMessage()
+            {
+                // Strip away MS-NNS framing
+                var header = new byte[5];
+                _stream.Read(header, 0, 1);
+                _stream.Read(header, 1, 4);
+                var length = (header[3] << 8) + header[4];
+                var retVal = new byte[length]; // return non-null even for 0
+                if (length > 0)
+                {
+                    _stream.Read(retVal, 0, retVal.Length);
+                }
+                if (header[0] == 21) throw new Exception("Received ERROR record");
+                return retVal;
+            }
+            internal void WriteData(byte[] message, int offset, int count)
+            {
+                // Do MS-NNS framing
+                var header = new byte[4];
+                header[0] = (byte)(count & 0xff);
+                header[1] = (byte)((count >> 8) & 0xff);
+                header[2] = (byte)((count >> 16) & 0xff);
+                header[3] = (byte)((count >> 24) & 0xff);
+                _stream.Write(header, 0, header.Length);
+
+                if (count > 0)
+                {
+                    _stream.Write(message, offset, count);
+                }
+            }
+            internal int ReadData(byte[] buffer, int offset, int count)
+            {
+                // Strip away MS-NNS framing
+                var header = new byte[4];
+                _stream.Read(header, 0, 4);
+                var length = (header[3] << 24) + (header[2] << 16) + (header[1] << 8) + header[0];
+                if (length > 0)
+                {
+                    _stream.Read(buffer, offset, Math.Min(count, length));
+                }
+                return length;
+            }
+        }
+#endregion
+    }
+}

--- a/src/Common/src/Interop/Unix/libgssapi/MockUtils.cs
+++ b/src/Common/src/Interop/Unix/libgssapi/MockUtils.cs
@@ -1,0 +1,295 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+
+namespace MockUtils
+{
+    using socklen_t = System.UInt32;
+#if CODE_ANALYSIS
+    using size_t = System.Int32;
+#else
+    using size_t = System.IntPtr;
+#endif
+
+    internal static class Interop
+    {
+#if CODE_ANALYSIS
+        private const string mylib = "WS2_32";
+
+        [DllImport(mylib, SetLastError = true)]
+        internal static extern int WSAStartup(short version, IntPtr data);
+
+        [DllImport(mylib, SetLastError = true)]
+        internal static extern int WSASocket(int domain, int type, int protocol, IntPtr zero, int zero2, int zero3);
+#else
+        private const string mylib = "libc";
+
+        [DllImport(mylib, SetLastError = true)]
+        internal unsafe static extern int write(int fd, byte* buf, ulong len);
+
+        [DllImport(mylib, SetLastError = true)]
+        internal static extern int socket(int domain, int type, int protocol);
+#endif
+
+        [DllImport(mylib, SetLastError = true)]
+        internal unsafe static extern int send(int sockfd, byte* buf, size_t len, int flags);
+
+        [DllImport(mylib, SetLastError = true)]
+        internal unsafe static extern int recv(int sockfd, byte* buf, size_t len, int flags);
+
+        [DllImport(mylib, SetLastError = true)]
+        internal unsafe static extern int connect(int sockfd, byte* addr, socklen_t addrlen);
+
+        [DllImport(mylib, SetLastError = true)]
+        internal unsafe static extern int bind(int sockfd, byte* addr, socklen_t addrlen);
+
+        [DllImport(mylib, SetLastError = true)]
+        internal unsafe static extern int setsockopt(int sockfd, int level, int optname, ref int optval, socklen_t optlen);
+
+        [DllImport(mylib, SetLastError = true)]
+        internal unsafe static extern int listen(int sockfd, int backlog);
+
+        [DllImport(mylib, SetLastError = true)]
+        internal unsafe static extern int accept(int sockfd, byte* addr, IntPtr addrlen);
+    }
+
+    internal static class MockLogging
+    {
+        private static void Print(string msg)
+        {
+            string logHeader = "[" + Environment.CurrentManagedThreadId.ToString("d4") + "] ";
+#if CODE_ANALYSIS
+            Console.Write(logHeader + msg);
+#else
+            var byteBuf = Encoding.UTF8.GetBytes(logHeader + msg);
+            unsafe
+            {
+                fixed (byte* bytePtr = byteBuf)
+                {
+                    Interop.write(1, bytePtr, (ulong)byteBuf.Length);
+                }
+            }
+#endif
+        }
+
+        internal static void PrintInfo(object t, string message)
+        {
+            Print(message + "\n");
+        }
+
+        internal static void Dump(object t, object t2, string method, byte[] buf, int offset, int len)
+        {
+            unsafe
+            {
+                fixed (byte* ptr = buf)
+                {
+                    Dump(t, t2, method, new IntPtr(ptr + offset), len);
+                }
+            }
+        }
+
+        internal static void Dump(object t, object t2, string method, IntPtr buf, int len)
+        {
+            Print("DUMPING from " + method + ": " + len + " bytes" + "\n");
+            if (len > 256) len = 256;
+            for (int i = 0; i < len;)
+            {
+                var s1 = new StringBuilder(16*3);
+                var s2 = new StringBuilder(16);
+
+                var s0 = "\t" + (i & (~0xf)).ToString("x8") + "\t";
+                for (int j = 0; j < 16; j++, i++)
+                {
+                    if (i < len)
+                    {
+                        var b = Marshal.ReadByte(buf, i);
+                        s1.Append(b.ToString("X2") + " ");
+                        var c = (b > 31 && b < 128) ? Convert.ToChar(b) : '.';
+                        s2.Append(c);
+                    }
+                    else
+                    {
+                        s1.Append("   ");
+                    }
+                }
+                Print(s0 + s1.ToString() + "\t" + s2.ToString() + "\n");
+            }
+        }
+
+        internal static void PrintLine(object t, TraceEventType t2, int t3, string message)
+        {
+            PrintInfo(null, message);
+        }
+
+        internal static void PrintError(object t, string message)
+        {
+            PrintInfo(null, message);
+        }
+    }
+
+    internal class SocketStream : MemoryStream
+    {
+        protected int _socket;
+        protected static readonly byte[] s_connBuffer = new byte[] { 2, 0, 0x11, 0x51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+#if CODE_ANALYSIS
+        static SocketStream()
+        {
+            var ret = Interop.WSAStartup((short)0x202, Marshal.AllocHGlobal(1000));
+            if (ret != 0) throw new Exception("WSAStartup failed: " + ret);
+        }
+#endif
+
+        public SocketStream(int socket)
+        {
+            _socket = socket;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var retVal = SendRecvHelper(_socket, buffer, offset, count, false);
+            return retVal;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var retVal = SendRecvHelper(_socket, buffer, offset, count, true);
+        }
+        protected static int GetPort(int port)
+        {
+            if (port == 0) port = (s_connBuffer[2] << 8) + s_connBuffer[3];
+            return port;
+        }
+
+        protected static int GetSocket()
+        {
+#if CODE_ANALYSIS
+            var socket = Interop.WSASocket(2, 1, 0, IntPtr.Zero, 0, 0);
+#else
+            var socket = Interop.socket(2, 1, 0);
+#endif
+            return socket;
+        }
+
+        private static int SendRecvHelper(int sockFd, byte[] buffer, int offset, int count, bool isSend)
+        {
+            var method = isSend ? "SendHelper" : "RecvHelper";
+            unsafe
+            {
+                fixed (byte* bytePtr = buffer)
+                {
+#if CODE_ANALYSIS
+                    size_t bufSize = (size_t)count;
+#else
+                    size_t bufSize = new IntPtr(count);
+#endif
+                    if (isSend)
+                    {
+                        count = Interop.send(sockFd, bytePtr + offset, bufSize, 0);
+                    }
+                    else
+                    {
+                        count = Interop.recv(sockFd, bytePtr + offset, bufSize, 0);
+                    }
+
+                    MockLogging.PrintLine(null, TraceEventType.Verbose, 0, method + ": " + count);
+                    if (count < 0)
+                    {
+                        MockLogging.PrintError(null, method + " failed: " + count + " errno: " + Marshal.GetLastWin32Error());
+                        throw new Exception(method);
+                    }
+                    if (isSend) MockLogging.PrintLine(null, TraceEventType.Verbose, 0, method + " sent: " + count);
+                    else
+                    {
+                        MockLogging.Dump(null, null, method, buffer, offset, count);
+                    }
+                    return count;
+                }
+            }
+        }
+    }
+
+    internal class ClientStream : SocketStream
+    {
+        public ClientStream(string server, int port)
+            : base(-1)
+        {
+            if (String.IsNullOrEmpty(server)) server = "127.0.0.1";
+            _socket = CreateServerConnection(IPAddress.Parse(server), GetPort(port));
+        }
+
+        private static int CreateServerConnection(IPAddress server, int port)
+        {
+            var client = GetSocket();
+            var size = s_connBuffer.Length;
+            var buffer = new byte[size];
+            Array.Copy(s_connBuffer, buffer, size);
+            var addrBytes = server.GetAddressBytes();
+            Array.Copy(addrBytes, 0, buffer, 4, 4);
+
+            unsafe
+            {
+                fixed (byte* pinnedBuffer = buffer)
+                {
+                    var retVal = Interop.connect(client, pinnedBuffer, (socklen_t)size);
+                    if (retVal < 0) throw new Exception("connect returned: " + retVal);
+                    return client;
+                }
+            }
+        }
+    }
+
+    internal class ServerStream : SocketStream
+    {
+        internal ServerStream(int port)
+            : base(-1)
+        {
+            _socket = AcceptClientConnection(GetPort(port));
+        }
+
+        private int AcceptClientConnection(int port)
+        {
+            var listenSocket = GetSocket();
+            var size = s_connBuffer.Length;
+            var buffer = s_connBuffer;
+            unsafe
+            {
+                fixed (byte* pinnedBuffer = buffer)
+                {
+                    var retVal = Interop.bind(listenSocket, pinnedBuffer, (socklen_t)size);
+#if false
+                    if (retVal < 0) throw new Exception("bind returned: " + retVal);
+                    int on=1;
+                    retVal = Interop.setsockopt(listenSocket, 1, 2, ref on, (socklen_t)4);
+                    if (retVal < 0) throw new Exception("setsockopt returned: " + retVal);
+#else
+                    int retry = 20,delay=500,i=1; // 10 seconds == 20 * 500
+                    while (retVal < 0 && i <= retry)
+                    {
+                        retVal = Interop.bind(listenSocket, pinnedBuffer, (socklen_t)size);
+                        if (retVal >= 0) break;
+                        else if (i == retry) throw new Exception("bind returned: " + retVal);
+                        i++;
+                        System.Threading.Tasks.Task.Delay(delay).Wait();
+                    }
+#endif
+                    retVal = Interop.listen(listenSocket, 1);
+                    if (retVal < 0) throw new Exception("listen returned: " + retVal);
+                    MockLogging.PrintInfo(null, "listen returned: " + retVal + ". Waiting for client connection...");
+                    var paddr = Marshal.AllocHGlobal(sizeof(socklen_t));
+                    Marshal.WriteInt32(paddr, 0, size);
+                    var acceptSocket = Interop.accept(listenSocket, pinnedBuffer, paddr);
+                    MockLogging.PrintInfo(null, "AcceptClientConnection returned: " + acceptSocket);
+                    return acceptSocket;
+                }
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libgssapi/Program.cs
+++ b/src/Common/src/Interop/Unix/libgssapi/Program.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+#if CODE_ANALYSIS
+using System.Net.Security;
+using System.Security.Principal;
+#endif
+
+namespace Sample
+{
+    using MockUtils;
+#if CODE_ANALYSIS
+    using MockNegotiateStream = System.Net.Security.NegotiateStream;
+    using MockCredential = System.Net.NetworkCredential;
+    using MockProtection = System.Net.Security.ProtectionLevel;
+    using MockImpersonation = System.Security.Principal.TokenImpersonationLevel;
+#else
+    using MockNegotiateStream;
+#endif
+    public class Program
+    {
+        private static void TestNegotiateClient(MockCredential cred, string target, string server, int port)
+        {
+            using (var stream = new ClientStream(server, port))
+            {
+                var negoStream = new MockNegotiateStream(stream);
+                var isNtlm = String.IsNullOrEmpty(target);
+                var protectionLevel = MockProtection.EncryptAndSign;
+#if CODE_ANALYSIS
+                if (!isNtlm) cred = CredentialCache.DefaultNetworkCredentials; // to allow testing with real Windows logged-on credentials
+                else protectionLevel = MockProtection.None; // reqd to force NTLM auth
+#endif
+                // Use WCF defaults for ChannelBinding & TokenImpersonationLevel
+                negoStream.AuthenticateAsClient(cred, null, target, protectionLevel, MockImpersonation.Identification);
+                MockLogging.PrintInfo(null, "____Connected to " + negoStream.RemoteIdentity.Name);
+                var sendBuf = Encoding.UTF8.GetBytes("Hello " + (isNtlm ? "NTLMv2" : "SPNEGO") + "\n");
+                negoStream.Write(sendBuf, 0, sendBuf.Length);
+                MockLogging.PrintInfo(null, "Waiting for data from server....");
+                var recvBuf = new byte[1000];
+                var ret = negoStream.Read(recvBuf, 0, recvBuf.Length);
+                MockLogging.Dump(null, null, "TestNegotiateClient", recvBuf, 0, ret);
+            }
+        }
+
+        private static void TestNegotiateServer(MockCredential cred, int port)
+        {
+            using (var stream = new ServerStream(port))
+            {
+                var negoStream = new MockNegotiateStream(stream);
+#if CODE_ANALYSIS
+                // Use None protection to allow Windows NTLM client
+                negoStream.AuthenticateAsServer(CredentialCache.DefaultNetworkCredentials, null, ProtectionLevel.None, TokenImpersonationLevel.Identification);
+#else
+                // Use WCF defaults for ExtendedProtectionPolic & TokenImpersonationLevel
+                negoStream.AuthenticateAsServer(cred, null, impersonation: MockImpersonation.Identification);
+#endif
+                MockLogging.PrintInfo(null, "____Connected to " + negoStream.RemoteIdentity.Name);
+                MockLogging.PrintInfo(null, "Waiting for data from client....");
+                var recvBuf = new byte[1000];
+                var ret = negoStream.Read(recvBuf, 0, recvBuf.Length);
+                MockLogging.Dump(null, null, "TestNegotiateServer", recvBuf, 0, ret);
+                negoStream.Write(recvBuf, 0, ret);
+            }
+        }
+
+        private static void PrintUsage(string[] args)
+        {
+            MockLogging.PrintInfo(null, "\nWithout arguments, run in server mode");
+            MockLogging.PrintInfo(null, "To run in client mode, pass targetname, username and password. Optionally pass server");
+            MockLogging.PrintInfo(null, "\n\t eg: MockNego.exe");
+            MockLogging.PrintInfo(null, "\t eg: MockNego.exe myservice/testbox.com@TESTBOX.REALM testuser password 1.2.3.4\n");
+            MockLogging.PrintInfo(null, "Make sure that targetname is exactly how the SPN is defined on the KDC\n");
+        }
+
+        public static void Main(string[] args)
+        {
+            if(args == null || args.Length<1)
+            {
+                TestNegotiateServer(null, 0);
+            }
+#if false
+            else if (args.Length == 1)
+            {
+                TestNegotiateServer(null, Int32.Parse(args[0]));
+            }
+#endif
+            else if (args.Length >= 3)
+            {
+                var domain = args[0].Contains("@") ? string.Empty : args[0];
+                var target = args[0].Contains("@") ? args[0] : string.Empty;
+                var cred = new MockCredential
+                {
+                    UserName = args[1],
+                    Password = args[2],
+                    Domain = domain,
+                };
+                var server = args.Length > 3 ? args[3] : null;
+#if false
+                var port = args.Length > 4 ? Int32.Parse(args[4]) : 0;
+#endif
+                TestNegotiateClient(cred, target, server, 0);
+            }
+            else
+            {
+                PrintUsage(args);
+            }
+        }  
+    }
+}

--- a/src/Common/src/Interop/Unix/libgssapi/Resources/Strings.resx
+++ b/src/Common/src/Interop/Unix/libgssapi/Resources/Strings.resx
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="net_generic_operation_failed" xml:space="preserve">
+    <value>GSSAPI operation failed with status: {0} (Minor status: {1})</value>
+  </data>
+  <data name="net_context_establishment_failed" xml:space="preserve">
+    <value>GSSAPI security context establishment failed with status: {0} (Minor status: {1})</value>
+  </data>
+  <data name="net_context_wrap_failed" xml:space="preserve">
+    <value>GSSAPI encryption or signing failed with status: {0} (Minor status: {1})</value>
+  </data>
+  <data name="net_context_unwrap_failed" xml:space="preserve">
+    <value>GSSAPI decryption or signature verification failed with status: {0} (Minor status: {1})</value>
+  </data>
+  <data name="net_context_buffer_too_small" xml:space="preserve">
+    <value>Insufficient buffer space. Required: {0} Actual: {1}</value>
+  </data>
+  <data name="net_generic_heimntlm_operation_failed" xml:space="preserve">
+    <value>Heimdal NTLM operation failed with error: {0}</value>
+  </data>
+</root>

--- a/src/Common/src/Interop/Unix/libgssapi/project.json
+++ b/src/Common/src/Interop/Unix/libgssapi/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "System.Diagnostics.Contracts": "4.0.0-*",
+    "System.Threading": "4.0.0-*",
+    "System.Console": "4.0.0-beta-*",
+    "System.Text.Encoding": "4.0.10",
+    "System.Net.Primitives": "4.0.10-beta-*",
+    "System.Security.Cryptography.OpenSsl": "4.0.0-beta-*",
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/Common/src/Interop/Unix/libheimntlm/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/libheimntlm/Interop.Crypto.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class libheimntlm
+    {
+        #region To be shimmed
+        // TODO (Issue: 3717) : Check or create shims
+        [DllImport("libcrypto")]
+        private static extern IntPtr EVP_MD_CTX_create();
+        [DllImport("libcrypto")]
+        private static extern void EVP_MD_CTX_destroy(IntPtr ctx);
+        [DllImport("libcrypto")]
+        private static extern IntPtr EVP_md5();
+        [DllImport("libcrypto")]
+        private static extern void EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+        [DllImport("libcrypto")]
+        private static unsafe extern void EVP_DigestUpdate(IntPtr ctx, byte* d, size_t cnt);
+        [DllImport("libcrypto")]
+        private static unsafe extern void EVP_DigestFinal_ex(IntPtr ctx, byte* md, out uint s);
+        private const int EVP_MAX_MD_SIZE = 64;
+        [StructLayout(LayoutKind.Sequential)]
+        private struct EVP_MD_CTX
+        {
+            public IntPtr digest;
+            public IntPtr engine;
+            public ulong flags;
+            public IntPtr md_data;
+            public IntPtr pctx;
+            public IntPtr update;
+        }
+        [StructLayout(LayoutKind.Sequential)]
+        private unsafe struct HMAC_CTX
+        {
+            public IntPtr md;
+            public EVP_MD_CTX md_ctx;
+            public EVP_MD_CTX i_ctx;
+            public EVP_MD_CTX o_ctx;
+            public uint key_length;
+            public fixed byte key[128];
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct RC4_KEY
+        {
+            public int x;
+            public int y;
+            public fixed int data[256];
+        }
+
+        private const int EVP_MAX_IV_LENGTH = 16;
+        private const int EVP_MAX_BLOCK_LENGTH = 32;
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct EVP_CIPHER_CTX
+        {
+            public IntPtr cipher;
+            public IntPtr engine;
+            public int encrypt;
+            public int buf_len;
+            public fixed byte oiv[EVP_MAX_IV_LENGTH];
+            public fixed byte iv[EVP_MAX_IV_LENGTH];
+            public fixed byte buf[EVP_MAX_BLOCK_LENGTH];
+            public int num;
+            public IntPtr app_data;
+            public int key_len;
+            public ulong flags;
+            public IntPtr cipher_data;
+            public int final_used;
+            public int block_mask;
+            private fixed byte final [EVP_MAX_BLOCK_LENGTH];
+        }
+        [DllImport("libcrypto")]
+        private static extern void HMAC_CTX_init(ref HMAC_CTX ctx);
+        [DllImport("libcrypto")]
+        private static extern void HMAC_CTX_cleanup(ref HMAC_CTX ctx);
+        [DllImport("libcrypto")]
+        private static unsafe extern void HMAC_Init_ex(ref HMAC_CTX ctx, byte* key, int key_len, IntPtr md, IntPtr impl);
+        [DllImport("libcrypto")]
+        private static unsafe extern void HMAC_Update(ref HMAC_CTX ctx, byte* data, int len);
+        [DllImport("libcrypto")]
+        private static unsafe extern void HMAC_Final(ref HMAC_CTX ctx, byte* md, out uint len);
+        [DllImport("libcrypto")]
+        private static unsafe extern void RC4_set_key(ref RC4_KEY key, int len, byte* data);
+        [DllImport("libcrypto")]
+        private static unsafe extern void RC4(ref RC4_KEY key, ulong len, byte* indata, byte* outdata);
+        [DllImport("libcrypto")]
+        private static extern IntPtr EVP_rc4();
+        [DllImport("libcrypto")]
+        private static extern void EVP_CIPHER_CTX_init(ref EVP_CIPHER_CTX ctx);
+        [DllImport("libcrypto")]
+        private static extern int EVP_CIPHER_CTX_cleanup(ref EVP_CIPHER_CTX ctx);
+        [DllImport("libcrypto")]
+        private static unsafe extern void EVP_CipherInit_ex(ref EVP_CIPHER_CTX ctx, IntPtr type, IntPtr impl, byte* key, IntPtr iv, int enc);
+        [DllImport("libcrypto")]
+        private static unsafe extern int EVP_Cipher(ref EVP_CIPHER_CTX ctx, byte* output, byte* input, int inl);
+        #endregion
+
+        internal static unsafe RC4_KEY RC4Init(byte* key, int keylen)
+        {
+            RC4_KEY rc4Key = new RC4_KEY();
+            RC4_set_key(ref rc4Key, keylen, key);
+            return rc4Key;
+        }
+
+        internal static unsafe byte[] RC4EncryptOrDecrypt(RC4_KEY rc4Key, byte* input, int inputlen)
+        {
+            byte[] output = new byte[inputlen];
+            fixed (byte* outPtr = output)
+            {
+                RC4(ref rc4Key, (ulong)inputlen, input, outPtr);
+            }
+            return output;
+        }
+
+        internal static unsafe byte[] EVPDigest(byte* key, int keylen, byte* input, int inputlen, out uint outputlen)
+        {
+            byte[] output = new byte[EVP_MAX_MD_SIZE];
+            IntPtr ctx = EVP_MD_CTX_create();
+            try
+            {
+                EVP_DigestInit_ex(ctx, EVP_md5(), IntPtr.Zero);
+                EVP_DigestUpdate(ctx, key, (size_t)keylen);
+                EVP_DigestUpdate(ctx, input, (size_t)inputlen);
+                unsafe
+                {
+                    fixed (byte* outPtr = output)
+                    {
+                        EVP_DigestFinal_ex(ctx, outPtr, out outputlen);
+                    }
+                }
+            }
+            finally
+            {
+                EVP_MD_CTX_destroy(ctx);
+            }
+            return output;
+        }
+
+        internal static unsafe byte[] EVPEncryptOrDecrypt(int x, bool encrypt, byte* key, int keylen, byte* input, int inputlen)
+        {
+            if (x > 0)
+            {
+                EVP_CIPHER_CTX ctx = EVPAllocateContext(encrypt, key, keylen);
+                try
+                {
+                    return EVPEncryptOrDecrypt(ctx, input, inputlen);
+                }
+                finally
+                {
+                    EVPFreeContext(ctx);
+                }
+            }
+            else
+            {
+                byte[] output = new byte[inputlen];
+                RC4_KEY k = new RC4_KEY();
+                RC4_set_key(ref k, keylen, key);
+                fixed (byte* outPtr = output)
+                {
+                    RC4(ref k, (ulong) inputlen, input, outPtr);
+                }
+                return output;
+            }
+        }
+
+        internal static unsafe EVP_CIPHER_CTX EVPAllocateContext(bool encrypt, byte* key, int keylen)
+        {
+            EVP_CIPHER_CTX ctx = new EVP_CIPHER_CTX();
+            EVP_CIPHER_CTX_init(ref ctx);
+            try
+            {
+                EVP_CipherInit_ex(ref ctx, EVP_rc4(), IntPtr.Zero, key, IntPtr.Zero, encrypt ? 1 : 0);
+            }
+            catch
+            {
+                EVPFreeContext(ctx);
+                throw;
+            }
+            return ctx;
+        }
+
+        internal static void EVPFreeContext(EVP_CIPHER_CTX ctx)
+        {
+            EVP_CIPHER_CTX_cleanup(ref ctx);
+        }
+
+        internal static unsafe byte[] EVPEncryptOrDecrypt(bool encrypt, byte* key, int keylen, byte* input, int inputlen)
+        {
+            EVP_CIPHER_CTX ctx = EVPAllocateContext(encrypt, key, keylen);
+            try
+            {
+                return EVPEncryptOrDecrypt(ctx, input, inputlen);
+            }
+            finally
+            {
+                EVPFreeContext(ctx);
+            }
+        }
+
+        internal static unsafe byte[] EVPEncryptOrDecrypt(EVP_CIPHER_CTX ctx, byte* input, int inputlen)
+        {
+            byte[] output = new byte[inputlen];
+
+            fixed (byte* outPtr = output)
+            {
+                EVP_Cipher(ref ctx, outPtr, input, output.Length);
+            }
+            return output;
+        }
+
+        internal static unsafe byte[] HMACDigest(byte* key, int keylen, byte* input, int inputlen, byte* prefix, int prefixlen)
+        {
+            HMAC_CTX ctx = new HMAC_CTX();
+            byte[] output = new byte[16];
+
+            HMAC_CTX_init(ref ctx);
+            try
+            {
+                HMAC_Init_ex(ref ctx, key, keylen, EVP_md5(), IntPtr.Zero);
+                if (prefixlen > 0)
+                {
+                    HMAC_Update(ref ctx, prefix, prefixlen);
+                }
+                HMAC_Update(ref ctx, input, inputlen);
+                fixed (byte* hashPtr = output)
+                {
+                    uint hashLength;
+                    HMAC_Final(ref ctx, hashPtr, out hashLength);
+                }
+            }
+            finally
+            {
+                HMAC_CTX_cleanup(ref ctx);
+            }
+            return output;
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libheimntlm/Interop.HeimdalNtlm.cs
+++ b/src/Common/src/Interop/Unix/libheimntlm/Interop.HeimdalNtlm.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using SafeNtlmBufferHandle = Interop.libheimntlm.SafeNtlmBufferHandle;
+using SafeNtlmType3Handle = Interop.libheimntlm.SafeNtlmType3Handle;
+using SafeNtlmKeyHandle = Interop.libheimntlm.SafeNtlmKeyHandle;
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static class HeimdalNtlm
+    {
+        internal static byte[] CreateNegotiateMessage(uint flags)
+        {
+            libheimntlm.ntlm_type1 message = new libheimntlm.ntlm_type1();
+            message.flags = flags;
+
+            using (SafeNtlmBufferHandle data = new SafeNtlmBufferHandle())
+            {
+                int status = libheimntlm.heim_ntlm_encode_type1(ref message, data);
+                libheimntlm.HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_encode_type1 failed", status);
+
+                byte[] outputBuffer = new byte[(int)data.Length]; // Always return non-null
+                if (outputBuffer.Length > 0)
+                {
+                    Marshal.Copy(data.Value, outputBuffer, 0, outputBuffer.Length);
+                }
+
+                return outputBuffer;
+            }
+        }
+
+        internal static byte[] CreateAuthenticateMessage(uint flags, string username, string password, string domain,
+            byte[] type2Data, int offset, int count, out SafeNtlmBufferHandle sessionKey)
+        {
+            using (SafeNtlmBufferHandle inputData = new SafeNtlmBufferHandle(type2Data, offset, count))
+            using (SafeNtlmType3Handle outputMessage = new SafeNtlmType3Handle(inputData))
+            using (SafeNtlmBufferHandle outputData = outputMessage.GetResponse(flags, username, password, domain, out sessionKey))
+            {
+                byte[] outputBuffer = new byte[(int) outputData.Length]; // Always return non-null
+                if (outputBuffer.Length > 0)
+                {
+                    Marshal.Copy(outputData.Value, outputBuffer, 0, outputBuffer.Length);
+                }
+                return outputBuffer;
+            }
+        }
+
+        internal static void CreateKeys(SafeNtlmBufferHandle sessionKey, out SafeNtlmKeyHandle serverSignKey, out SafeNtlmKeyHandle serverSealKey, out SafeNtlmKeyHandle clientSignKey, out SafeNtlmKeyHandle clientSealKey)
+        {
+            serverSignKey = new SafeNtlmKeyHandle(sessionKey, false, true);
+            serverSealKey = new SafeNtlmKeyHandle(sessionKey, false, false);
+            clientSignKey = new SafeNtlmKeyHandle(sessionKey, true, true);
+            clientSealKey = new SafeNtlmKeyHandle(sessionKey, true, false);
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libheimntlm/Interop.HeimdalNtlmException.cs
+++ b/src/Common/src/Interop/Unix/libheimntlm/Interop.HeimdalNtlmException.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class libheimntlm
+    {
+        internal sealed class HeimdalNtlmException : Exception
+        {
+            public HeimdalNtlmException(string message) : base(message)
+            {
+            }
+
+            public HeimdalNtlmException(int error)
+                : base(SR.Format(SR.net_generic_heimntlm_operation_failed, error))
+            {
+                HResult = error;
+            }
+
+
+            public static HeimdalNtlmException Create(string message)
+            {
+                return new HeimdalNtlmException(message);
+            }
+
+            public static HeimdalNtlmException Create(int error)
+            {
+                return new HeimdalNtlmException(error);
+            }
+
+            public static void AssertOrThrowIfError(string message, int error)
+            {
+                if (error != 0)
+                {
+                    var ex = Create(error);
+                    Debug.Fail(message + ": " + ex);
+                    throw ex;
+                }
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libheimntlm/Interop.SafeNtlmHandle.cs
+++ b/src/Common/src/Interop/Unix/libheimntlm/Interop.SafeNtlmHandle.cs
@@ -1,0 +1,393 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class libheimntlm
+    {
+        /// <summary>
+        /// Wrapper around a ntlm_buf*
+        /// </summary>
+        internal sealed class SafeNtlmBufferHandle : SafeHandle
+        {
+            private readonly bool _isOutputBuffer;
+            private readonly GCHandle _gch;
+            private readonly GCHandle _arrayGcHandle = new GCHandle();
+
+            // Return the buffer size
+            public size_t Length
+            {
+                get
+                {
+                    if (IsInvalid)
+                    {
+                        return (size_t)0;
+                    }
+                    return ((ntlm_buf)_gch.Target).length;
+                }
+            }
+
+            // Return a pointer to where data resides
+            public IntPtr Value
+            {
+                get
+                {
+                    if (IsInvalid)
+                    {
+                        return IntPtr.Zero;
+                    }
+                    return ((ntlm_buf)_gch.Target).data;
+                }
+            }
+
+            public SafeNtlmBufferHandle()
+                : this(0, IntPtr.Zero)
+            {
+                _isOutputBuffer = true;
+            }
+
+            public SafeNtlmBufferHandle(byte[] data) : this(data, 0, (data == null) ? 0 : data.Length)
+            {
+            }
+
+            public SafeNtlmBufferHandle(byte[] data, int offset, int count) : this(count, IntPtr.Zero)
+            {
+                if (data != null)
+                {
+                    _arrayGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+                    IntPtr address = new IntPtr(_arrayGcHandle.AddrOfPinnedObject().ToInt64() + offset);
+                    Marshal.WriteIntPtr(handle, (int) Marshal.OffsetOf<ntlm_buf>("data"), address);
+                }
+            }
+
+            public SafeNtlmBufferHandle(int length, IntPtr value)
+                : base(IntPtr.Zero, true)
+            {
+                ntlm_buf buffer = new ntlm_buf
+                    {
+                        length = (size_t)length,
+                        data = value,
+                    };
+                _gch = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                handle = _gch.AddrOfPinnedObject();
+            }
+
+            public override bool IsInvalid
+            {
+                get { return handle == IntPtr.Zero; }
+            }
+
+            public ntlm_buf ToBuffer()
+            {
+                return (ntlm_buf) _gch.Target;
+            }
+
+            // Note that _value should never be freed directly. For input
+            // buffer, it is owned by the caller and for output buffer,
+            // it is a by-product of some other allocation
+            protected override bool ReleaseHandle()
+            {
+                ntlm_buf buffer = (ntlm_buf)_gch.Target;
+                if (_isOutputBuffer && (buffer.data != IntPtr.Zero))
+                {
+                    if (_arrayGcHandle.IsAllocated)
+                    {
+                        _arrayGcHandle.Free();
+                    }
+                    else
+                    {
+                        heim_ntlm_free_buf(ref buffer);
+                    }
+                    buffer.data = IntPtr.Zero;
+                }
+                _gch.Free();
+                SetHandle(IntPtr.Zero);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Wrapper around a session key used for signing
+        /// </summary>
+        internal sealed class SafeNtlmKeyHandle : SafeHandle
+        {
+            private GCHandle _gch;
+            private uint _keyLength;
+            private uint _sequenceNumber;
+            private bool _isSealingKey;
+            private readonly EVP_CIPHER_CTX _cipherContext;
+
+            // From MS_NLMP SIGNKEY at https://msdn.microsoft.com/en-us/library/cc236711.aspx
+            private const string s_keyMagic = "session key to {0}-to-{1} {2} key magic constant\0";
+            private const string s_client = "client";
+            private const string s_server = "server";
+            private const string s_signing = "signing";
+            private const string s_sealing = "sealing";
+
+            public SafeNtlmKeyHandle(SafeNtlmBufferHandle key, bool isClient, bool sign)
+                : base(IntPtr.Zero, true)
+            {
+                string keyMagic = string.Format(s_keyMagic, isClient ? s_client : s_server,
+                    isClient ? s_server : s_client, sign ? s_signing : s_sealing);
+                unsafe
+                {
+                    byte[] magic = Encoding.UTF8.GetBytes(keyMagic);
+                    fixed (byte* magicPtr = magic)
+                    {
+                        byte[] digest = EVPDigest((byte*) key.Value.ToPointer(), (int) key.Length, magicPtr,
+                            magic.Length, out _keyLength);
+                        _isSealingKey = !sign;
+                        if (_isSealingKey)
+                        {
+                            fixed (byte* digestPtr = digest)
+                            {
+                                _cipherContext = EVPAllocateContext(true, digestPtr, digest.Length);
+                            }
+                        }
+                        _gch = GCHandle.Alloc(digest, GCHandleType.Pinned);
+                        handle = _gch.AddrOfPinnedObject();
+                    }
+                }
+            }
+
+            public override bool IsInvalid
+            {
+                get { return handle == IntPtr.Zero; }
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                if (_isSealingKey)
+                {
+                    EVPFreeContext(_cipherContext);
+                }
+                _gch.Free();
+                SetHandle(IntPtr.Zero);
+                return true;
+            }
+
+            public byte[] Sign(SafeNtlmKeyHandle sealingKey, byte[] buffer, int offset, int count)
+            {
+                Debug.Assert(!_isSealingKey, "Cannot sign with sealing key");
+                byte[] output = new byte[16];
+                Array.Clear(output, 0, output.Length);
+                byte[] hash;
+                unsafe
+                {
+                    fixed (byte* outPtr = output)
+                    fixed (byte* bytePtr = buffer)
+                    {
+                        MarshalUint(outPtr, 0x00000001); // version
+                        MarshalUint(outPtr + 12, _sequenceNumber);
+                        hash = HMACDigest((byte*)handle.ToPointer(), (int)_keyLength, (bytePtr + offset), count,
+                            outPtr + 12, 4);
+                        _sequenceNumber++;
+                    }
+                }
+                if ((sealingKey == null) || sealingKey.IsInvalid)
+                {
+                    Array.Copy(hash, 0, output, 4, 8);
+                }
+                else
+                {
+                    byte[] cipher = sealingKey.SealOrUnseal(true, hash, 0, 8);
+                    Array.Copy(cipher, 0, output, 4, cipher.Length);
+                }
+                return output;
+            }
+
+            public byte[] SealOrUnseal(bool seal, byte[] buffer, int offset, int count)
+            {
+                Debug.Assert(_isSealingKey, "Cannot seal or unseal with signing key");
+                unsafe
+                {
+                    fixed (byte* bytePtr = buffer)
+                    {
+                        // Since RC4 is XOR-based, encrypt or decrypt is relative to input data
+                        return EVPEncryptOrDecrypt(_cipherContext, (bytePtr + offset), count);
+                    }
+                }
+            }
+
+#if DEBUG
+            public void Dump(string message)
+            {
+                MockUtils.MockLogging.Dump(null, "SafeNtlmBufferHandle.Dump", message, handle, (int) _keyLength);
+            }
+#endif
+
+            private static unsafe void MarshalUint(byte* ptr, uint num)
+            {
+                for (int i = 0; i < 4; i++)
+                {
+                    ptr[i] = (byte)(num & 0xff);
+                    num >>= 8;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wrapper around a ntlm_type3*
+        /// </summary>
+        internal sealed class SafeNtlmType3Handle : SafeHandle
+        {
+            // heim_ntlm_encode_type3 requires a valid pointer for this
+            private static readonly IntPtr s_workstationPtr = Marshal.StringToHGlobalAnsi(string.Empty);
+
+            private GCHandle _gch;
+
+            public SafeNtlmType3Handle(SafeNtlmBufferHandle type2Data) : base(IntPtr.Zero, true)
+            {
+                ntlm_type2 message = new ntlm_type2();
+                int status = heim_ntlm_decode_type2(type2Data, ref message);
+                HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_decode_type2 failed", status);
+
+                _gch = GCHandle.Alloc(message, GCHandleType.Pinned);
+                handle = _gch.AddrOfPinnedObject();
+            }
+
+            public override bool IsInvalid
+            {
+                get { return handle == IntPtr.Zero; }
+            }
+
+            public SafeNtlmBufferHandle GetResponse(uint flags, string username, string password, string domain, out SafeNtlmBufferHandle sessionKey)
+            {
+                SafeNtlmBufferHandle outputData = new SafeNtlmBufferHandle();
+                sessionKey = null;
+                ntlm_type2 type2Message = (ntlm_type2)_gch.Target;
+
+                using (SafeNtlmBufferHandle key = new SafeNtlmBufferHandle())
+                using (SafeNtlmBufferHandle lmResponse = new SafeNtlmBufferHandle())
+                using (SafeNtlmBufferHandle ntResponse = new SafeNtlmBufferHandle())
+                {
+                    int status = heim_ntlm_nt_key(password, key);
+                    HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_nt_key failed", status);
+
+                    byte[] baseSessionKey = new byte[16];
+                    unsafe
+                    {
+                        byte* challenge = type2Message.challenge;
+                        fixed (byte* sessionKeyPtr = baseSessionKey)
+                        {
+                            status = heim_ntlm_calculate_lm2(key.Value, key.Length, username, domain, challenge,
+                                sessionKeyPtr, lmResponse);
+                            HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_calculate_lm2 failed", status);
+                        }
+                        if (type2Message.targetinfo.length == (size_t)0)
+                        {
+                            status = heim_ntlm_calculate_ntlm1(key.Value, key.Length, challenge, ntResponse);
+                            HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_calculate_ntlm1 failed", status);
+                        }
+                        else
+                        {
+                            using (
+                                SafeNtlmBufferHandle targetInfo =
+                                    new SafeNtlmBufferHandle((int)type2Message.targetinfo.length,
+                                        type2Message.targetinfo.data))
+                            {
+                                fixed (byte* sessionKeyPtr = baseSessionKey)
+                                {
+                                    status = heim_ntlm_calculate_ntlm2(key.Value, key.Length, username,
+                                        domain,
+                                        challenge,
+                                        targetInfo, sessionKeyPtr, ntResponse);
+                                    HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_calculate_ntlm2 failed",
+                                        status);
+                                }
+                            }
+                        }
+                    }
+
+                    ntlm_type3 type3Message = new ntlm_type3();
+                    type3Message.flags = flags;
+                    SafeNtlmBufferHandle masterKey = null;
+                    try
+                    {
+                        type3Message.username = Marshal.StringToHGlobalAnsi(username);
+                        type3Message.targetname = Marshal.StringToHGlobalAnsi(domain);
+                        type3Message.lm = lmResponse.ToBuffer();
+                        type3Message.ntlm = ntResponse.ToBuffer();
+                        type3Message.ws = s_workstationPtr;
+                        sessionKey = new SafeNtlmBufferHandle();    // Should not Dispose on success
+
+                        if (type2Message.targetinfo.length == (size_t) 0)
+                        {
+                            masterKey = new SafeNtlmBufferHandle();
+                            unsafe
+                            {
+                                status = heim_ntlm_build_ntlm1_master((byte*) key.Value.ToPointer(),
+                                    key.Length, sessionKey, masterKey);
+                            }
+                            HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_build_ntlm1_master failed", status);
+                        }
+                        else
+                        {
+                            // Only first 16 bytes of the NTLMv2 response should be passed
+                            using (
+                                SafeNtlmBufferHandle blob = new SafeNtlmBufferHandle(16,
+                                    ntResponse.Value))
+                            {
+                                unsafe
+                                {
+                                    fixed (byte* sessionKeyPtr = baseSessionKey)
+                                    {
+                                        heim_ntlm_build_ntlm2_master(sessionKeyPtr,
+                                            (size_t) baseSessionKey.Length, blob, sessionKey, out masterKey);
+                                    }
+                                }
+                            }
+                        }
+                        type3Message.session_key = masterKey.ToBuffer();
+
+                        size_t micOffset = (size_t) 0;
+                        status = heim_ntlm_encode_type3(ref type3Message, outputData, ref micOffset);
+                        HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_encode_type3 failed", status);
+                    }
+                    catch
+                    {
+                        if ((sessionKey != null) && !sessionKey.IsInvalid)
+                        {
+                            sessionKey.Dispose();
+                            sessionKey = null;
+                        }
+                        throw;
+                    }
+                    finally
+                    {
+                        if (type3Message.username != IntPtr.Zero)
+                        {
+                            Marshal.FreeHGlobal(type3Message.username);
+                        }
+                        if (type3Message.targetname != IntPtr.Zero)
+                        {
+                            Marshal.FreeHGlobal(type3Message.targetname);
+                        }
+                        if ((masterKey != null) && !masterKey.IsInvalid)
+                        {
+                            masterKey.Dispose();
+                        }
+                    }
+                }
+
+                return outputData;
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                heim_ntlm_free_type2(handle);
+                _gch.Free();
+                SetHandle(IntPtr.Zero);
+                return true;
+            }
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libheimntlm/Interop.libheimntlm.cs
+++ b/src/Common/src/Interop/Unix/libheimntlm/Interop.libheimntlm.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class Libraries
+    {
+        // TODO (Issue #3717): Figure out the correct library on OSX
+        internal const string LibHeimNtlm = "libheimntlm.so.0";
+    }
+
+    internal static partial class libheimntlm
+    {
+        [DllImport(Interop.Libraries.LibHeimNtlm)]
+        internal static extern int heim_ntlm_free_buf(
+            ref ntlm_buf data);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm)]
+        internal static extern int heim_ntlm_encode_type1(
+            ref ntlm_type1 type1,
+            SafeNtlmBufferHandle data);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm)]
+        internal static extern int heim_ntlm_decode_type2(
+            SafeNtlmBufferHandle data,
+            ref ntlm_type2 type2);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm)]
+        internal static extern int heim_ntlm_free_type2(
+            IntPtr type2);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm, CharSet = CharSet.Ansi)]
+        internal static extern unsafe int heim_ntlm_nt_key(
+            string password,
+            SafeNtlmBufferHandle key);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm, CharSet=CharSet.Ansi)]
+        internal static extern unsafe int heim_ntlm_calculate_lm2(
+            IntPtr key,
+            size_t len,
+            string username,
+            string target,
+            byte* serverchallenge,
+            byte* ntlmv2,
+            SafeNtlmBufferHandle answer);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm)]
+        internal static extern unsafe int heim_ntlm_calculate_ntlm1(
+            IntPtr key,
+            size_t len,
+            byte* serverchallenge,
+            SafeNtlmBufferHandle answer);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm, CharSet = CharSet.Ansi)]
+        internal static extern unsafe int heim_ntlm_calculate_ntlm2(
+            IntPtr key,
+            size_t len,
+            string username,
+            string target,
+            byte* serverchallenge,
+            SafeNtlmBufferHandle infotarget,
+            byte* ntlmv2,
+            SafeNtlmBufferHandle answer);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm)]
+        internal static extern int heim_ntlm_encode_type3(
+            ref ntlm_type3 type3,
+            SafeNtlmBufferHandle data,
+            ref size_t mic_offset);
+
+        [DllImport(Interop.Libraries.LibHeimNtlm)]
+        internal static extern unsafe int heim_ntlm_build_ntlm1_master(
+            byte* key,
+            size_t len,
+            SafeNtlmBufferHandle session,
+            SafeNtlmBufferHandle master);
+
+        // This is not yet available in libheimntlm
+        internal static unsafe void heim_ntlm_build_ntlm2_master(
+            byte* key,
+            size_t len,
+            SafeNtlmBufferHandle blob,
+            SafeNtlmBufferHandle session,
+            out SafeNtlmBufferHandle master)
+        {
+            byte[] exchangeKey = HMACDigest(key, (int)len, (byte*)blob.Value.ToPointer(), (int)blob.Length, null, 0);
+            fixed (byte* keyPtr = exchangeKey)
+            {
+                using (SafeNtlmBufferHandle tempMaster = new SafeNtlmBufferHandle())
+                {
+                    int status = heim_ntlm_build_ntlm1_master(keyPtr, (size_t) exchangeKey.Length, session, tempMaster);
+                    HeimdalNtlmException.AssertOrThrowIfError("heim_ntlm_build_ntlm1_master failed",
+                        status);
+                }
+
+                byte[] exportKey = EVPEncryptOrDecrypt(true, keyPtr, exchangeKey.Length, (byte*)session.Value.ToPointer(), (int)session.Length);
+                master = new SafeNtlmBufferHandle(exportKey);
+            }
+        }
+
+    }
+}

--- a/src/Common/src/Interop/Unix/libheimntlm/Interop.libheimntlm_types.cs
+++ b/src/Common/src/Interop/Unix/libheimntlm/Interop.libheimntlm_types.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using size_t = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class libheimntlm
+    {
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct ntlm_buf
+        {
+            internal size_t length;
+            internal IntPtr data;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct ntlm_type1
+        {
+            internal uint flags;
+            internal uint padding;
+            internal IntPtr domain;
+            internal IntPtr hostname;
+            internal fixed uint os[2];
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct ntlm_type2
+        {
+            internal uint flags;
+            internal uint padding;
+            internal IntPtr targetname;
+            internal ntlm_buf targetinfo;
+            internal fixed byte challenge[8];
+            internal fixed uint context[2];
+            internal fixed uint os[2];
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct ntlm_type3
+        {
+            internal uint flags;
+            internal uint padding;
+            internal IntPtr username;
+            internal IntPtr targetname;
+            internal ntlm_buf lm;
+            internal ntlm_buf ntlm;
+            internal ntlm_buf session_key;
+            internal IntPtr ws;
+            internal fixed uint os[2];
+            internal size_t mic_offset;
+            internal fixed byte mic [16];
+        }
+
+        internal partial class NtlmFlags
+        {
+            internal const uint NTLMSSP_NEGOTIATE_UNICODE = 0x1;
+            internal const uint NTLMSSP_REQUEST_TARGET = 0x4;
+            internal const uint NTLMSSP_NEGOTIATE_SIGN = 0x10;
+            internal const uint NTLMSSP_NEGOTIATE_SEAL = 0x20;
+            internal const uint NTLMSSP_NEGOTIATE_NTLM = 0x200;
+            internal const uint NTLMSSP_NEGOTIATE_ALWAYS_SIGN = 0x8000;
+            internal const uint NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY = 0x80000;
+            internal const uint NTLMSSP_NEGOTIATE_128 = 0x20000000;
+            internal const uint NTLMSSP_NEGOTIATE_KEY_EXCH = 0x40000000;
+        }
+    }
+}

--- a/src/System.Net.Security/src/System/Net/NegotiateStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/NegotiateStreamPal.Unix.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    // Depending on PAL refactoring, this will either be part of a class that implements
+    // SSPIInterfaceNego or Unix-specific files (eg. _NTAuthenticationPal.Unix.cs) will 
+    // call into methods of this class
+    internal static class NegotiateStreamPal
+    {
+        public static SecurityStatus AcquireCredentialsHandle(
+            string moduleName,
+            bool isInBoundCred,
+            string username,
+            string password,
+            string domain,
+            out SafeFreeGssCredentials outCredential)
+        {
+            if (isInBoundCred || string.IsNullOrEmpty(username))
+            {
+                // In server case, only the keytab file (eg. /etc/krb5.keytab) is used
+                // In client case, equivalent of default credentials is to use previous,
+                // unexpired Kerberos TGT to get service-specific ticket.
+                outCredential = new SafeFreeGssCredentials(string.Empty, string.Empty, string.Empty);
+            }
+            else
+            {
+                outCredential = new SafeFreeGssCredentials(username, password, domain);
+            }
+            return SecurityStatus.OK;
+        }
+
+        public static SecurityStatus AcquireDefaultCredential(string moduleName, bool isInBoundCred, out SafeFreeGssCredentials outCredential)
+        {
+            return AcquireCredentialsHandle(moduleName, isInBoundCred, string.Empty, string.Empty, string.Empty, out outCredential);
+        }
+
+        public static SecurityStatus AcceptSecurityContext(
+            SafeFreeGssCredentials credential,
+            ref SafeDeleteGssContext context,
+            SecurityBuffer inputBuffer,
+            uint inFlags,
+            uint endianNess,
+            SecurityBuffer outputBuffer,
+            ref uint outFlags)
+        {
+            return EstablishSecurityContext(credential, ref context, string.Empty, inFlags, inputBuffer, outputBuffer, ref outFlags);
+        }
+
+        public static SecurityStatus InitializeSecurityContext(
+            SafeFreeGssCredentials credential,
+            ref SafeDeleteGssContext context,
+            string targetName,
+            uint inFlags,
+            uint endianNess,
+            SecurityBuffer[] inputBuffers,
+            SecurityBuffer outputBuffer,
+            ref uint outFlags)
+        {
+            // TODO (Issue #3718): The second buffer can contain a channel binding which is not yet supported
+            if (inputBuffers.Length > 1)
+            {
+                throw new NotImplementedException("No support for channel binding on non-Windows");
+            }
+            return EstablishSecurityContext(credential, ref context, targetName, inFlags, inputBuffers[0], outputBuffer, ref outFlags);
+        }
+
+        public static int EncryptOrSignMessage(SafeDeleteGssContext securityContext, byte[] buffer, int offset, int count, ref byte[] output, uint sequenceNumber)
+        {
+            // Sequence number is not used by libgssapi
+            return Interop.GssApi.Encrypt(securityContext.GssContext, securityContext.NeedsEncryption, buffer, offset, count, out output);
+        }
+
+        public static int DecryptOrVerifyMessage(SafeDeleteGssContext securityContext, byte[] buffer, int offset, int count, out int newOffset, uint sequenceNumber)
+        {
+            // Sequence number is not used by libgssapi
+            count = Interop.GssApi.Decrypt(securityContext.GssContext, buffer, offset, count);
+            newOffset = 0;
+            return count;
+        }
+
+        public static object QueryContextAttributes(SafeDeleteGssContext context, uint attribute, out SecurityStatus errorCode)
+        {
+            errorCode = SecurityStatus.OK;
+            switch (attribute)
+            {
+                case 0x01: // Names
+                    return Interop.GssApi.GetSourceName(context.GssContext);
+                case 0x0C: // NegotiationInfo
+                    NegotiationInfoClass negotiationInfoClass = new NegotiationInfoClass(context, Int32.MaxValue);
+                    negotiationInfoClass.AuthenticationPackage = NegotiationInfoClass.Kerberos;
+                    return negotiationInfoClass;
+                case 0: // Sizes
+                    // Used only in the Encrypt/Decrypt logic
+                case 0x1B: // ClientSpecifiedSpn
+                    // Required only in NTLM case with ExtendedProtection
+                default:
+                    errorCode = SecurityStatus.Unsupported;
+                    return null;
+            }
+        }
+
+        private static SecurityStatus EstablishSecurityContext(
+            SafeFreeGssCredentials credential,
+            ref SafeDeleteGssContext context,
+            string targetName,
+            uint inFlags,
+            SecurityBuffer inputBuffer,
+            SecurityBuffer outputBuffer,
+            ref uint outFlags)
+        {
+            if (context == null)
+            {
+                context = new SafeDeleteGssContext(targetName, inFlags);
+            }
+
+            try
+            {
+                Interop.libgssapi.SafeGssContextHandle gssContext = context.GssContext;
+                bool done = Interop.GssApi.EstablishSecurityContext(
+                                  ref gssContext,
+                                  credential,
+                                  context.TargetName,
+                                  inFlags,
+                                  inputBuffer.token,
+                                  out outputBuffer.token,
+                                  out outFlags);
+
+                Debug.Assert(outputBuffer.token != null, "Unexpected null buffer returned by GssApi");
+                outputBuffer.size = outputBuffer.token.Length;
+                outputBuffer.offset = 0;
+
+                // Save the inner context handle for further calls to libgssapi
+                if (context.IsInvalid)
+                {
+                    context.SetHandle(credential, gssContext);
+                }
+                return done ? SecurityStatus.OK : SecurityStatus.ContinueNeeded;
+            }
+            catch (Exception)
+            {
+                return SecurityStatus.InternalError;
+            }
+        }
+    }   
+}


### PR DESCRIPTION
Sending an early PR of xplat NegotiateStream code that should be immune to churn in System.Net.Security. The idea is to make the code production-ready in parallel with changes under System.Net.Security. Some familiarity with System.Net.Security.SslStream code would help in reviewing.
